### PR TITLE
Implement UX review fixes for lesson and revision flow

### DIFF
--- a/src/screens/LessonScreen/LessonHeader/LessonHeader.styles.ts
+++ b/src/screens/LessonScreen/LessonHeader/LessonHeader.styles.ts
@@ -34,6 +34,14 @@ export const ProgressTracker = styled.View(({ theme }) => ({
   gap: scale(theme.spacing.xs)
 }))
 
+export const Title = styled(Typography)(({ theme }) => ({
+  position: 'absolute',
+  left: 0,
+  right: 0,
+  textAlign: 'center',
+  color: theme.colors.text
+}))
+
 export const ProgressText = styled(Typography)(() => ({}))
 
 export const XMarksContainer = styled.View(({ theme }) => ({

--- a/src/screens/LessonScreen/LessonHeader/index.tsx
+++ b/src/screens/LessonScreen/LessonHeader/index.tsx
@@ -6,6 +6,7 @@ import {
   Header,
   ProgressText,
   ProgressTracker,
+  Title,
   XMark,
   XMarksContainer
 } from './LessonHeader.styles'
@@ -16,6 +17,7 @@ interface LessonHeaderProps {
   totalQuestions: number
   wrongAnswersCount: number
   onBackPress: () => void
+  title?: string
 }
 
 export const LessonHeader = ({
@@ -23,7 +25,8 @@ export const LessonHeader = ({
   currentQuestionIndex,
   totalQuestions,
   wrongAnswersCount,
-  onBackPress
+  onBackPress,
+  title
 }: LessonHeaderProps) => {
   const { isTablet } = useDevice()
   return (
@@ -31,7 +34,13 @@ export const LessonHeader = ({
       <BackButton testID="back-button" onPress={onBackPress}>
         <BackArrowIcon size={16} />
       </BackButton>
-      
+
+      {title && (
+        <Title size="md" weight="semibold">
+          {title}
+        </Title>
+      )}
+
       {lesson?.isFinalTest ? (
         <ProgressTracker>
           <ProgressText

--- a/src/screens/LessonScreen/components/AnswerInterface/index.tsx
+++ b/src/screens/LessonScreen/components/AnswerInterface/index.tsx
@@ -4,7 +4,7 @@ import { isEnharmonicEquivalent } from '@/utils/enharmonicMap'
 import { playErrorSound, playSuccessSound } from '@/utils/soundUtils'
 import type { Question } from '@types'
 import { useEffect, useMemo, useState } from 'react'
-import { Text } from 'react-native'
+import { Pressable, Text } from 'react-native'
 import { AnswerInterfaceContainer } from './AnswerInterface.styles'
 import { RhythmTap } from './AnswerTypes/RhythmTap'
 import { KeyPress } from './AnswerTypes/KeyPress'
@@ -38,6 +38,7 @@ export const AnswerInterface = ({
   onPlaybackFinishRef
 }: AnswerInterfaceProps) => {
   const [answerResult, setAnswerResult] = useState<{ selected: string; correct: boolean } | null>(null)
+  const [skippedDelay, setSkippedDelay] = useState(false)
 
   const showResult = answerResult !== null
   const isCorrect = answerResult?.correct ?? null
@@ -57,19 +58,19 @@ export const AnswerInterface = ({
   }, [answerResult, isFinalTest, onShowExplanation])
 
   useEffect(() => {
-    if (answerResult === null) return
+    if (answerResult === null || skippedDelay) return
 
     const { correct } = answerResult
     if (!correct && !isFinalTest) return
 
     const totalWrong = wrongAnswersCount + (correct ? 0 : 1)
-    const shouldBlock = isFinalTest && !correct && totalWrong > FINAL_TEST_FAILURE_THRESHOLD
+    const shouldBlock = isFinalTest && !correct && totalWrong >= FINAL_TEST_FAILURE_THRESHOLD
 
     if (shouldBlock) return
 
     const timer = setTimeout(() => onNextQuestion(), CORRECT_ANSWER_DELAY)
     return () => clearTimeout(timer)
-  }, [answerResult, wrongAnswersCount, isFinalTest, onNextQuestion])
+  }, [answerResult, wrongAnswersCount, isFinalTest, onNextQuestion, skippedDelay])
 
   const handleAnswer = (answer: string, correct: boolean) => {
     if (answerResult !== null) return
@@ -85,6 +86,11 @@ export const AnswerInterface = ({
 
   const handleKeyPress = (key: string) => {
     handleAnswer(key, isEnharmonicEquivalent(key, correctAnswerStr))
+  }
+
+  const handleSkipDelay = () => {
+    setSkippedDelay(true)
+    onNextQuestion()
   }
 
   const playbackInterface = questionData.questionInterface?.type === 'playback' ? questionData.questionInterface : undefined
@@ -170,9 +176,11 @@ export const AnswerInterface = ({
   }
 
   return (
-    <AnswerInterfaceContainer>
-      {renderAnswerComponent()}
-    </AnswerInterfaceContainer>
+    <Pressable onPress={showResult && isCorrect ? handleSkipDelay : undefined}>
+      <AnswerInterfaceContainer>
+        {renderAnswerComponent()}
+      </AnswerInterfaceContainer>
+    </Pressable>
   )
 }
 

--- a/src/screens/LessonScreen/components/FinalTestModal/index.tsx
+++ b/src/screens/LessonScreen/components/FinalTestModal/index.tsx
@@ -19,7 +19,7 @@ const CONFIG = {
       'You\'ve passed the final test! Great work on mastering this stage.'
   },
   failure: {
-    icon: '❌',
+    icon: '🎯',
     title: 'Not quite yet!',
     description:
       'You\'ve reached the maximum wrong answers. Don\'t worry - practise makes perfect! Review the lessons and try again.'

--- a/src/screens/LessonScreen/components/LessonCompleteModal/index.tsx
+++ b/src/screens/LessonScreen/components/LessonCompleteModal/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/compLib/Modal/Modal.styles'
 import { getStarDescription, getStarMessage } from '@/utils/starCalculation'
 import { useEffect, useRef, useState } from 'react'
-import { Animated } from 'react-native'
+import { Animated, Text } from 'react-native'
 import {
   AnimatedStarContainer,
   StarContainer,
@@ -80,34 +80,51 @@ export const LessonCompleteModal = ({
     }
   }, [visible, stars, starAnimations])
 
-  const renderStars = () => {
-    return Array.from({ length: 3 }, (_, index) => {
-      const isFilled = index < animatedStars
-      const animation = starAnimations[index]
-
+  const renderStarDisplay = () => {
+    if (stars === 0) {
       return (
-        <AnimatedStarContainer
-          key={index}
-          style={{
-            opacity: animation,
-            transform: [{
-              scale: animation.interpolate({
-                inputRange: [0, 1],
-                outputRange: [0.3, 1]
-              })
-            }]
-          }}
-        >
-          <StarIcon
-            filled={isFilled}
-            size={isTablet ? 'xl' : 'xxl'}
-            align="center"
-          >
-            {isFilled ? '⭐' : '☆'}
-          </StarIcon>
-        </AnimatedStarContainer>
+        <StarContainer>
+          <Text style={{ fontSize: isTablet ? 48 : 64, marginBottom: 12 }}>
+            📚
+          </Text>
+          <Text style={{ fontSize: 16, fontWeight: '600', textAlign: 'center', opacity: 0.7 }}>
+            Keep practising to unlock stars!
+          </Text>
+        </StarContainer>
       )
-    })
+    }
+
+    return (
+      <StarContainer>
+        {Array.from({ length: 3 }, (_, index) => {
+          const isFilled = index < animatedStars
+          const animation = starAnimations[index]
+
+          return (
+            <AnimatedStarContainer
+              key={index}
+              style={{
+                opacity: animation,
+                transform: [{
+                  scale: animation.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [0.3, 1]
+                  })
+                }]
+              }}
+            >
+              <StarIcon
+                filled={isFilled}
+                size={isTablet ? 'xl' : 'xxl'}
+                align="center"
+              >
+                {isFilled ? '⭐' : '☆'}
+              </StarIcon>
+            </AnimatedStarContainer>
+          )
+        })}
+      </StarContainer>
+    )
   }
 
   return (
@@ -118,7 +135,7 @@ export const LessonCompleteModal = ({
     >
       <TitleText>{getStarMessage(stars)}</TitleText>
 
-      <StarContainer>{renderStars()}</StarContainer>
+      {renderStarDisplay()}
 
       <DescriptionText>
         {getStarDescription(stars, totalQuestions, wrongAnswers)}
@@ -131,7 +148,7 @@ export const LessonCompleteModal = ({
             variant="outlined"
             size="sm"
             onPress={onRetry}
-            label="Retry"
+            label="Try Again"
           />
         </ButtonItem>
 

--- a/src/screens/LessonScreen/index.tsx
+++ b/src/screens/LessonScreen/index.tsx
@@ -20,6 +20,7 @@ import { calculateStars } from '@/utils/starCalculation'
 import type { Question, StoreRevisionQuestionPayload } from '@types'
 import { useLocalSearchParams } from 'expo-router'
 import { useCallback, useState } from 'react'
+import { Alert, Pressable, Text, View } from 'react-native'
 import { FinalTestModal } from './components/FinalTestModal'
 import { LessonCompleteModal } from './components/LessonCompleteModal'
 import { LessonHeader } from './LessonHeader'
@@ -174,35 +175,45 @@ export const LessonScreen = () => {
     if (isCompleting) return // Prevent duplicate calls
     setIsCompleting(true)
 
-    if (lesson?.isFinalTest) {
-      // Final test: pass/fail, show success modal or navigate back
-      const isPassed = wrongAnswers.length < 3
+    try {
+      if (lesson?.isFinalTest) {
+        // Final test: pass/fail, show success modal or navigate back
+        const isPassed = wrongAnswers.length < 3
 
-      if (lessonId) {
-        await updateFinalTestProgress(lessonId, isPassed)
+        if (lessonId) {
+          await updateFinalTestProgress(lessonId, isPassed)
+        }
+        await storeRevisionQuestions()
+
+        if (!isPassed) {
+          navigateBack()
+          return
+        }
+
+        playLessonFinishedSound()
+        setShowSuccessModal(true)
+      } else {
+        // Regular lesson: stars, modal, user can retry/continue
+        const stars = calculateStars(questions.length, wrongAnswers.length)
+
+        if (lessonId) {
+          await updateLessonProgress(lessonId, stars)
+        }
+        await storeRevisionQuestions()
+
+        const soundToPlay =
+          stars === 0 ? playLessonFailedSound : playLessonFinishedSound
+        soundToPlay()
+
+        setShowStarModal(true)
       }
-      await storeRevisionQuestions()
-
-      if (!isPassed) {
-        navigateBack()
-        return
-      }
-
-      playLessonFinishedSound()
-      setShowSuccessModal(true)
-    } else {
-      // Regular lesson: stars, modal, user can retry/continue
-      const stars = calculateStars(questions.length, wrongAnswers.length)
-      setShowStarModal(true)
-
-      const soundToPlay =
-        stars === 0 ? playLessonFailedSound : playLessonFinishedSound
-      soundToPlay()
-
-      if (lessonId) {
-        await updateLessonProgress(lessonId, stars)
-      }
-      await storeRevisionQuestions()
+    } catch (error) {
+      setIsCompleting(false)
+      Alert.alert(
+        'Save failed',
+        'Your progress could not be saved. Please try again.',
+        [{ text: 'OK' }]
+      )
     }
   }, [
     isCompleting,
@@ -216,7 +227,21 @@ export const LessonScreen = () => {
     navigateBack
   ])
 
-  if (!lesson || questions.length === 0) return null
+  if (!lesson || questions.length === 0) {
+    return (
+      <ScreenContainer>
+        <View style={{ padding: 16, paddingTop: 12 }}>
+          <Pressable onPress={navigateBack} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+            <Text style={{ fontSize: 24, fontWeight: '600' }}>← Back</Text>
+          </Pressable>
+        </View>
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 }}>
+          <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, textAlign: 'center' }}>Lesson not found</Text>
+          <Text style={{ fontSize: 14, textAlign: 'center', opacity: 0.7 }}>Unable to load this lesson. Please try again or go back.</Text>
+        </View>
+      </ScreenContainer>
+    )
+  }
 
   const navigateAfterModal = () => {
     if (from === 'home') {
@@ -224,6 +249,13 @@ export const LessonScreen = () => {
     } else {
       navigateBack()
     }
+  }
+
+  const handleBackPress = () => {
+    Alert.alert('Leave lesson?', 'Your progress will be lost.', [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Leave', onPress: navigateBack, style: 'destructive' }
+    ])
   }
 
   const closeModalAndExit = () => {
@@ -267,7 +299,7 @@ export const LessonScreen = () => {
         currentQuestionIndex={currentQuestionIndex}
         totalQuestions={questions.length}
         wrongAnswersCount={wrongAnswers.length}
-        onBackPress={navigateBack}
+        onBackPress={handleBackPress}
       />
 
       <LessonScreenBody

--- a/src/screens/RevisionScreen/components/RevisionCompletionModal/index.tsx
+++ b/src/screens/RevisionScreen/components/RevisionCompletionModal/index.tsx
@@ -10,6 +10,7 @@ import {
 interface RevisionCompletionModalProps {
   visible: boolean
   remainingQuestions: number
+  masteredQuestions?: number
   onExit: () => void
   onRevise: () => void
 }
@@ -17,6 +18,7 @@ interface RevisionCompletionModalProps {
 export const RevisionCompletionModal = ({
   visible,
   remainingQuestions,
+  masteredQuestions = 0,
   onExit,
   onRevise
 }: RevisionCompletionModalProps) => {
@@ -30,7 +32,9 @@ export const RevisionCompletionModal = ({
       <DescriptionText testID="revision-completion-description">
         {isAllComplete
           ? 'You\'ve completed all your revision questions! Great job!'
-          : `You have ${remainingQuestions} question${remainingQuestions !== 1 ? 's' : ''} left to revise.`}
+          : masteredQuestions > 0
+            ? `Great work! You mastered ${masteredQuestions} question${masteredQuestions !== 1 ? 's' : ''}. You have ${remainingQuestions} question${remainingQuestions !== 1 ? 's' : ''} left to revise.`
+            : `You have ${remainingQuestions} question${remainingQuestions !== 1 ? 's' : ''} left to revise.`}
       </DescriptionText>
       <ButtonContainer singleButton={isAllComplete}>
         {isAllComplete ? (

--- a/src/screens/RevisionScreen/index.tsx
+++ b/src/screens/RevisionScreen/index.tsx
@@ -1,6 +1,7 @@
 import { ScreenContainer } from '@/globalComponents/ScreenContainer'
 import { useProgress } from '@/hooks'
 import { useRouter } from 'expo-router'
+import { Pressable, Text, View } from 'react-native'
 import { LessonHeader } from '../LessonScreen/LessonHeader'
 import { LessonScreenBody } from '../LessonScreen/LessonScreenBody'
 import { RevisionCompletionModal } from './components/RevisionCompletionModal'
@@ -25,32 +26,48 @@ export const RevisionScreen = () => {
     onExit: () => router.back()
   })
 
-  if (!hasQuestions && !completion.showModal) return null
-
   return (
     <ScreenContainer>
-      <LessonHeader
-        lesson={null}
-        currentQuestionIndex={revision.currentQuestionIndex}
-        totalQuestions={revision.questions.length}
-        wrongAnswersCount={0}
-        onBackPress={() => router.back()}
-      />
+      {!hasQuestions && !completion.showModal ? (
+        <>
+          <View style={{ padding: 16, paddingTop: 12 }}>
+            <Pressable onPress={() => router.back()} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+              <Text style={{ fontSize: 24, fontWeight: '600' }}>← Back</Text>
+            </Pressable>
+          </View>
+          <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 }}>
+            <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, textAlign: 'center' }}>Nothing to revise yet</Text>
+            <Text style={{ fontSize: 14, textAlign: 'center', opacity: 0.7 }}>Keep going with your lessons! Difficult questions will appear here.</Text>
+          </View>
+        </>
+      ) : (
+        <>
+          <LessonHeader
+            lesson={null}
+            currentQuestionIndex={revision.currentQuestionIndex}
+            totalQuestions={revision.questions.length}
+            wrongAnswersCount={0}
+            onBackPress={() => router.back()}
+            title="Revision"
+          />
 
-      {hasQuestions && currentQuestion && (
-        <LessonScreenBody
-          key={revision.viewResetKey}
-          questions={revision.questions}
-          currentQuestionIndex={revision.currentQuestionIndex}
-          onAnswerSubmit={onAnswerSubmit}
-          onNextQuestion={goToNextQuestion}
-          onLessonComplete={completeRevision}
-        />
+          {hasQuestions && currentQuestion && (
+            <LessonScreenBody
+              key={revision.viewResetKey}
+              questions={revision.questions}
+              currentQuestionIndex={revision.currentQuestionIndex}
+              onAnswerSubmit={onAnswerSubmit}
+              onNextQuestion={goToNextQuestion}
+              onLessonComplete={completeRevision}
+            />
+          )}
+        </>
       )}
 
       <RevisionCompletionModal
         visible={completion.showModal && completion.status === 'completed'}
         remainingQuestions={completion.remainingCount}
+        masteredQuestions={completion.masteredCount ?? 0}
         onExit={handleExit}
         onRevise={handleRevise}
       />

--- a/src/screens/RevisionScreen/useRevision.ts
+++ b/src/screens/RevisionScreen/useRevision.ts
@@ -26,6 +26,7 @@ interface CompletionState {
   status: CompletionStatus;
   showModal: boolean;
   remainingCount: number;
+  masteredCount?: number;
 }
 
 interface UseRevisionParams {
@@ -201,11 +202,14 @@ export const useRevision = ({
         return
       }
       const remainingCount = result.remainingCount ?? 0
+      const initialCount = restart.questions.length
+      const masteredCount = initialCount - remainingCount
       setRevision((prev) => ({ ...prev, counts: result.counts }))
       setCompletion({
         status: 'completed',
         showModal: true,
-        remainingCount
+        remainingCount,
+        masteredCount
       })
       playLessonFinishedSound()
     } catch (error) {
@@ -216,7 +220,7 @@ export const useRevision = ({
         status: prev.status === 'completed' ? 'completed' : 'idle'
       }))
     }
-  }, [completion.status, updateRevision])
+  }, [completion.status, updateRevision, restart.questions.length])
 
   const restartRevision = useCallback(() => {
     cancelledCompletionGenerationRef.current = completionGenerationRef.current


### PR DESCRIPTION
BLOCKERs (3):
- Show error state with back button when lessonId is invalid or lesson not found
- Show empty state with back button when revision queue is empty
- Add confirmation dialog before exiting mid-lesson to prevent accidental data loss

FRICTION (5):
- Fix final test failure threshold off-by-one (AnswerInterface)
- Add 'Revision' label to revision session header for clarity
- Track and display mastered questions count in revision completion modal
- Await save operations before showing success modal to catch failures
- Allow tapping to skip auto-advance delay and move to next question immediately

POLISH (3):
- Add distinct visual state for 0-star lessons with book emoji and encouragement
- Change 'Retry' button label to 'Try Again' (warmer, clearer for young learners)
- Replace harsh ❌ emoji on final test failure with neutral 🎯 icon
